### PR TITLE
Improve hour quest progress display

### DIFF
--- a/src/main/java/org/maks/questsystem/commands/QuestPreviewCommand.java
+++ b/src/main/java/org/maks/questsystem/commands/QuestPreviewCommand.java
@@ -62,15 +62,15 @@ public class QuestPreviewCommand implements CommandExecutor, Listener {
         PlayerQuestData data = plugin.getQuestManager().getPlayerData(player.getUniqueId());
 
         // Daily quest item
-        ItemStack dailyItem = createQuestItem(data.getDailyQuest(), QuestType.DAILY);
+        ItemStack dailyItem = createQuestItem(data, data.getDailyQuest(), QuestType.DAILY);
         inv.setItem(11, dailyItem);
 
         // Weekly quest item
-        ItemStack weeklyItem = createQuestItem(data.getWeeklyQuest(), QuestType.WEEKLY);
+        ItemStack weeklyItem = createQuestItem(data, data.getWeeklyQuest(), QuestType.WEEKLY);
         inv.setItem(13, weeklyItem);
 
         // Monthly quest item
-        ItemStack monthlyItem = createQuestItem(data.getMonthlyQuest(), QuestType.MONTHLY);
+        ItemStack monthlyItem = createQuestItem(data, data.getMonthlyQuest(), QuestType.MONTHLY);
         inv.setItem(15, monthlyItem);
 
         // Info item
@@ -91,7 +91,7 @@ public class QuestPreviewCommand implements CommandExecutor, Listener {
         player.openInventory(inv);
     }
 
-    private ItemStack createQuestItem(Quest quest, QuestType type) {
+    private ItemStack createQuestItem(PlayerQuestData data, Quest quest, QuestType type) {
         Material material;
         String name;
         ChatColor color;
@@ -136,14 +136,15 @@ public class QuestPreviewCommand implements CommandExecutor, Listener {
             String progressBar = createProgressBar(quest.getCurrentProgress(), quest.getRequiredAmount());
             lore.add(ChatColor.YELLOW + "Progress: " + progressBar);
             
-            // For SPEND_HOURS_ONLINE quests, display time in minutes
+            // For SPEND_HOURS_ONLINE quests, display online time in minutes
             if (quest.getObjective() == QuestObjective.SPEND_HOURS_ONLINE) {
-                long currentMinutes = quest.getCurrentProgress() * 60;
+                long currentMinutes = data.getOnlineTime();
                 long requiredMinutes = quest.getRequiredAmount() * 60;
-                lore.add(ChatColor.YELLOW + "" + currentMinutes + "/" + requiredMinutes + " min" + 
-                        " (" + String.format("%.1f%%", quest.getProgressPercentage()) + ")");
+                double completion = (double) currentMinutes / requiredMinutes * 100;
+                lore.add(ChatColor.YELLOW + "" + currentMinutes + "/" + requiredMinutes + " min" +
+                        " (" + String.format("%.1f%%", completion) + ")");
             } else {
-                lore.add(ChatColor.YELLOW + "" + quest.getCurrentProgress() + "/" + quest.getRequiredAmount() + 
+                lore.add(ChatColor.YELLOW + "" + quest.getCurrentProgress() + "/" + quest.getRequiredAmount() +
                         " (" + String.format("%.1f%%", quest.getProgressPercentage()) + ")");
             }
             lore.add("");
@@ -207,7 +208,7 @@ public class QuestPreviewCommand implements CommandExecutor, Listener {
         }
     }
 
-    private void displayQuestProgress(Player player, Quest quest, QuestType type) {
+    private void displayQuestProgress(Player player, Quest quest, QuestType type, PlayerQuestData data) {
         ChatColor typeColor = getTypeColor(type);
         String typeName = getTypeName(type);
 
@@ -224,11 +225,12 @@ public class QuestPreviewCommand implements CommandExecutor, Listener {
         
         // For SPEND_HOURS_ONLINE quests, display time in minutes
         if (quest.getObjective() == QuestObjective.SPEND_HOURS_ONLINE) {
-            long currentMinutes = quest.getCurrentProgress() * 60;
+            long currentMinutes = data.getOnlineTime();
             long requiredMinutes = quest.getRequiredAmount() * 60;
-            player.sendMessage(ChatColor.GRAY + "Progress: " + progressBar + " " + 
-                             ChatColor.WHITE + currentMinutes + "/" + requiredMinutes + " min" + 
-                             " (" + String.format("%.1f%%", quest.getProgressPercentage()) + ")");
+            double completion = (double) currentMinutes / requiredMinutes * 100;
+            player.sendMessage(ChatColor.GRAY + "Progress: " + progressBar + " " +
+                             ChatColor.WHITE + currentMinutes + "/" + requiredMinutes + " min" +
+                             " (" + String.format("%.1f%%", completion) + ")");
         } else {
             player.sendMessage(ChatColor.GRAY + "Progress: " + progressBar + " " + 
                              ChatColor.WHITE + quest.getCurrentProgress() + "/" + quest.getRequiredAmount() + 

--- a/src/main/java/org/maks/questsystem/gui/QuestGUI.java
+++ b/src/main/java/org/maks/questsystem/gui/QuestGUI.java
@@ -43,15 +43,15 @@ public class QuestGUI implements Listener {
         PlayerQuestData data = plugin.getQuestManager().getPlayerData(player.getUniqueId());
 
         // Daily quest item
-        ItemStack dailyItem = createQuestItem(data.getDailyQuest(), QuestType.DAILY);
+        ItemStack dailyItem = createQuestItem(data, data.getDailyQuest(), QuestType.DAILY);
         inv.setItem(11, dailyItem);
 
         // Weekly quest item
-        ItemStack weeklyItem = createQuestItem(data.getWeeklyQuest(), QuestType.WEEKLY);
+        ItemStack weeklyItem = createQuestItem(data, data.getWeeklyQuest(), QuestType.WEEKLY);
         inv.setItem(13, weeklyItem);
 
         // Monthly quest item
-        ItemStack monthlyItem = createQuestItem(data.getMonthlyQuest(), QuestType.MONTHLY);
+        ItemStack monthlyItem = createQuestItem(data, data.getMonthlyQuest(), QuestType.MONTHLY);
         inv.setItem(15, monthlyItem);
 
         // Info item
@@ -72,7 +72,7 @@ public class QuestGUI implements Listener {
         player.openInventory(inv);
     }
 
-    private ItemStack createQuestItem(Quest quest, QuestType type) {
+    private ItemStack createQuestItem(PlayerQuestData data, Quest quest, QuestType type) {
         Material material;
         String name;
         ChatColor color;
@@ -113,12 +113,13 @@ public class QuestGUI implements Listener {
             lore.add(ChatColor.GRAY + quest.getDescription());
             lore.add("");
             
-            // For SPEND_HOURS_ONLINE quests, display time in minutes
+            // For SPEND_HOURS_ONLINE quests, display online time in minutes
             if (quest.getObjective() == QuestObjective.SPEND_HOURS_ONLINE) {
-                long currentMinutes = quest.getCurrentProgress() * 60;
+                long currentMinutes = data.getOnlineTime();
                 long requiredMinutes = quest.getRequiredAmount() * 60;
+                double completion = (double) currentMinutes / requiredMinutes * 100;
                 lore.add(ChatColor.YELLOW + "Progress: " + currentMinutes + "/" + requiredMinutes + " min");
-                lore.add(ChatColor.YELLOW + "Completion: " + String.format("%.1f%%", quest.getProgressPercentage()));
+                lore.add(ChatColor.YELLOW + "Completion: " + String.format("%.1f%%", completion));
             } else {
                 lore.add(ChatColor.YELLOW + "Progress: " + quest.getCurrentProgress() + "/" + quest.getRequiredAmount());
                 lore.add(ChatColor.YELLOW + "Completion: " + String.format("%.1f%%", quest.getProgressPercentage()));


### PR DESCRIPTION
## Summary
- show online minutes for hour quests in the Quest GUI
- show online minutes for hour quests in the Quest preview command

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6884e13e4910832a9ee6478581fccd30