### PR TITLE
Fix hour quest progress bar

### DIFF
--- a/src/main/java/org/maks/questsystem/commands/QuestPreviewCommand.java
+++ b/src/main/java/org/maks/questsystem/commands/QuestPreviewCommand.java
@@ -62,15 +62,15 @@ public class QuestPreviewCommand implements CommandExecutor, Listener {
         PlayerQuestData data = plugin.getQuestManager().getPlayerData(player.getUniqueId());
 
         // Daily quest item
-        ItemStack dailyItem = createQuestItem(data.getDailyQuest(), QuestType.DAILY);
+        ItemStack dailyItem = createQuestItem(data, data.getDailyQuest(), QuestType.DAILY);
         inv.setItem(11, dailyItem);
 
         // Weekly quest item
-        ItemStack weeklyItem = createQuestItem(data.getWeeklyQuest(), QuestType.WEEKLY);
+        ItemStack weeklyItem = createQuestItem(data, data.getWeeklyQuest(), QuestType.WEEKLY);
         inv.setItem(13, weeklyItem);
 
         // Monthly quest item
-        ItemStack monthlyItem = createQuestItem(data.getMonthlyQuest(), QuestType.MONTHLY);
+        ItemStack monthlyItem = createQuestItem(data, data.getMonthlyQuest(), QuestType.MONTHLY);
         inv.setItem(15, monthlyItem);
 
         // Info item
@@ -91,7 +91,7 @@ public class QuestPreviewCommand implements CommandExecutor, Listener {
         player.openInventory(inv);
     }
 
-    private ItemStack createQuestItem(Quest quest, QuestType type) {
+    private ItemStack createQuestItem(PlayerQuestData data, Quest quest, QuestType type) {
         Material material;
         String name;
         ChatColor color;
@@ -132,20 +132,24 @@ public class QuestPreviewCommand implements CommandExecutor, Listener {
             lore.add(ChatColor.GRAY + quest.getDescription());
             lore.add("");
 
-            // Progress bar
-            String progressBar = createProgressBar(quest.getCurrentProgress(), quest.getRequiredAmount());
+        // Progress bar
+        String progressBar;
+
+        // For SPEND_HOURS_ONLINE quests, display online time in minutes
+        if (quest.getObjective() == QuestObjective.SPEND_HOURS_ONLINE) {
+            int currentMinutes = (int) data.getOnlineTime();
+            int requiredMinutes = quest.getRequiredAmount() * 60;
+            progressBar = createProgressBar(currentMinutes, requiredMinutes);
+            double completion = (double) currentMinutes / requiredMinutes * 100;
             lore.add(ChatColor.YELLOW + "Progress: " + progressBar);
-            
-            // For SPEND_HOURS_ONLINE quests, display time in minutes
-            if (quest.getObjective() == QuestObjective.SPEND_HOURS_ONLINE) {
-                long currentMinutes = quest.getCurrentProgress() * 60;
-                long requiredMinutes = quest.getRequiredAmount() * 60;
-                lore.add(ChatColor.YELLOW + "" + currentMinutes + "/" + requiredMinutes + " min" + 
-                        " (" + String.format("%.1f%%", quest.getProgressPercentage()) + ")");
-            } else {
-                lore.add(ChatColor.YELLOW + "" + quest.getCurrentProgress() + "/" + quest.getRequiredAmount() + 
-                        " (" + String.format("%.1f%%", quest.getProgressPercentage()) + ")");
-            }
+            lore.add(ChatColor.YELLOW + "" + currentMinutes + "/" + requiredMinutes + " min" +
+                    " (" + String.format("%.1f%%", completion) + ")");
+        } else {
+            progressBar = createProgressBar(quest.getCurrentProgress(), quest.getRequiredAmount());
+            lore.add(ChatColor.YELLOW + "Progress: " + progressBar);
+            lore.add(ChatColor.YELLOW + "" + quest.getCurrentProgress() + "/" + quest.getRequiredAmount() +
+                    " (" + String.format("%.1f%%", quest.getProgressPercentage()) + ")");
+        }
             lore.add("");
 
             if (quest.isCompleted()) {
@@ -207,7 +211,7 @@ public class QuestPreviewCommand implements CommandExecutor, Listener {
         }
     }
 
-    private void displayQuestProgress(Player player, Quest quest, QuestType type) {
+    private void displayQuestProgress(Player player, Quest quest, QuestType type, PlayerQuestData data) {
         ChatColor typeColor = getTypeColor(type);
         String typeName = getTypeName(type);
 
@@ -219,19 +223,21 @@ public class QuestPreviewCommand implements CommandExecutor, Listener {
 
         player.sendMessage(typeColor + typeName + ": " + ChatColor.WHITE + quest.getDescription());
 
-        // Progress bar
-        String progressBar = createProgressBar(quest.getCurrentProgress(), quest.getRequiredAmount());
-        
+        String progressBar;
+
         // For SPEND_HOURS_ONLINE quests, display time in minutes
         if (quest.getObjective() == QuestObjective.SPEND_HOURS_ONLINE) {
-            long currentMinutes = quest.getCurrentProgress() * 60;
-            long requiredMinutes = quest.getRequiredAmount() * 60;
-            player.sendMessage(ChatColor.GRAY + "Progress: " + progressBar + " " + 
-                             ChatColor.WHITE + currentMinutes + "/" + requiredMinutes + " min" + 
-                             " (" + String.format("%.1f%%", quest.getProgressPercentage()) + ")");
+            int currentMinutes = (int) data.getOnlineTime();
+            int requiredMinutes = quest.getRequiredAmount() * 60;
+            progressBar = createProgressBar(currentMinutes, requiredMinutes);
+            double completion = (double) currentMinutes / requiredMinutes * 100;
+            player.sendMessage(ChatColor.GRAY + "Progress: " + progressBar + " " +
+                             ChatColor.WHITE + currentMinutes + "/" + requiredMinutes + " min" +
+                             " (" + String.format("%.1f%%", completion) + ")");
         } else {
-            player.sendMessage(ChatColor.GRAY + "Progress: " + progressBar + " " + 
-                             ChatColor.WHITE + quest.getCurrentProgress() + "/" + quest.getRequiredAmount() + 
+            progressBar = createProgressBar(quest.getCurrentProgress(), quest.getRequiredAmount());
+            player.sendMessage(ChatColor.GRAY + "Progress: " + progressBar + " " +
+                             ChatColor.WHITE + quest.getCurrentProgress() + "/" + quest.getRequiredAmount() +
                              " (" + String.format("%.1f%%", quest.getProgressPercentage()) + ")");
         }
 

--- a/src/main/java/org/maks/questsystem/gui/QuestGUI.java
+++ b/src/main/java/org/maks/questsystem/gui/QuestGUI.java
@@ -43,15 +43,15 @@ public class QuestGUI implements Listener {
         PlayerQuestData data = plugin.getQuestManager().getPlayerData(player.getUniqueId());
 
         // Daily quest item
-        ItemStack dailyItem = createQuestItem(data.getDailyQuest(), QuestType.DAILY);
+        ItemStack dailyItem = createQuestItem(data, data.getDailyQuest(), QuestType.DAILY);
         inv.setItem(11, dailyItem);
 
         // Weekly quest item
-        ItemStack weeklyItem = createQuestItem(data.getWeeklyQuest(), QuestType.WEEKLY);
+        ItemStack weeklyItem = createQuestItem(data, data.getWeeklyQuest(), QuestType.WEEKLY);
         inv.setItem(13, weeklyItem);
 
         // Monthly quest item
-        ItemStack monthlyItem = createQuestItem(data.getMonthlyQuest(), QuestType.MONTHLY);
+        ItemStack monthlyItem = createQuestItem(data, data.getMonthlyQuest(), QuestType.MONTHLY);
         inv.setItem(15, monthlyItem);
 
         // Info item
@@ -72,7 +72,7 @@ public class QuestGUI implements Listener {
         player.openInventory(inv);
     }
 
-    private ItemStack createQuestItem(Quest quest, QuestType type) {
+    private ItemStack createQuestItem(PlayerQuestData data, Quest quest, QuestType type) {
         Material material;
         String name;
         ChatColor color;
@@ -113,12 +113,13 @@ public class QuestGUI implements Listener {
             lore.add(ChatColor.GRAY + quest.getDescription());
             lore.add("");
             
-            // For SPEND_HOURS_ONLINE quests, display time in minutes
+            // For SPEND_HOURS_ONLINE quests, display online time in minutes
             if (quest.getObjective() == QuestObjective.SPEND_HOURS_ONLINE) {
-                long currentMinutes = quest.getCurrentProgress() * 60;
+                long currentMinutes = data.getOnlineTime();
                 long requiredMinutes = quest.getRequiredAmount() * 60;
+                double completion = (double) currentMinutes / requiredMinutes * 100;
                 lore.add(ChatColor.YELLOW + "Progress: " + currentMinutes + "/" + requiredMinutes + " min");
-                lore.add(ChatColor.YELLOW + "Completion: " + String.format("%.1f%%", quest.getProgressPercentage()));
+                lore.add(ChatColor.YELLOW + "Completion: " + String.format("%.1f%%", completion));
             } else {
                 lore.add(ChatColor.YELLOW + "Progress: " + quest.getCurrentProgress() + "/" + quest.getRequiredAmount());
                 lore.add(ChatColor.YELLOW + "Completion: " + String.format("%.1f%%", quest.getProgressPercentage()));


### PR DESCRIPTION
## Summary
- show minute-based progress bar for online hour quests

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6884e13e4910832a9ee6478581fccd30