### PR TITLE
Fix online time quest progress reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,7 @@ The plugin uses a `config.yml` file for configuration. You can customize:
 ## Notes
 
 This project was created as a clean implementation of the QuestSystem plugin to resolve issues with the original implementation.
+
+### Recent Changes
+
+- Fixed player online time not resetting after completing time-based quests.

--- a/src/main/java/org/maks/questsystem/managers/QuestManager.java
+++ b/src/main/java/org/maks/questsystem/managers/QuestManager.java
@@ -203,6 +203,11 @@ public class QuestManager {
             updateProgress(player, QuestObjective.COMPLETE_WEEKLY_QUESTS, 1, null);
         }
 
+        // Reset online time progress for SPEND_HOURS_ONLINE quests
+        if (quest.getObjective() == QuestObjective.SPEND_HOURS_ONLINE) {
+            data.resetOnlineTime();
+        }
+
         // Save to database
         plugin.getQuestDatabase().savePlayerData(data);
 


### PR DESCRIPTION
## Summary
- reset player's online time after claiming a SPEND_HOURS_ONLINE quest
- note time reset fix in README

## Testing
- `mvn package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68875b4d358c832aa7d3395cf3521df8